### PR TITLE
Fix bugs in cpu simulator

### DIFF
--- a/quantpy/sympy/executor/classical_simulation_executor.py
+++ b/quantpy/sympy/executor/classical_simulation_executor.py
@@ -22,8 +22,9 @@ class ClassicalSimulationExecutor(BaseQuantumExecutor):
 
     def execute(self, circuit, **options):
         """
-        execute sympy-circuit with classical simulator
-        we use numpy simulator as default
+        Execute sympy-circuit with classical simulator
+        We use numpy simulator as default
+        @param circuit sympy object to simulate
         """
         qasm = self.to_qasm(circuit)
         self.simulator = NumpySimulator()
@@ -36,6 +37,11 @@ class ClassicalSimulationExecutor(BaseQuantumExecutor):
         return None
 
     def simulate(self, circuitJson):
+        """
+        Simulate qasm script with json format
+        @param circuitJson qasm in json format
+        """
+
         sim = self.simulator
 
         numQubit = circuitJson["header"]["number_of_qubits"]
@@ -103,4 +109,8 @@ class ClassicalSimulationExecutor(BaseQuantumExecutor):
                 raise ValueError("Op:{} is contained in basis gates, but not supported in simulator".format(operation))
 
     def getStateStr(self):
+        """
+        Return string representation of the current quantum state
+        @return string representation of the current quantum state
+        """
         return str(self.simulator)

--- a/quantpy/sympy/executor/simulator/_base_simulator.py
+++ b/quantpy/sympy/executor/simulator/_base_simulator.py
@@ -1,13 +1,16 @@
-from abc import abstractmethod
+from abc import abstractmethod,ABCMeta
 
-
-class BaseSimulator:
+class BaseSimulator(metaclass=ABCMeta):
     def __init__(self):
-        self.basis_gates = ["x", "y", "z", "h", "s", "t", "cx", "cz", "m0", "m1"]
+        self.basis_gates = None
+
+    @abstractmethod
+    def initialize(self,n):
+        pass
 
     @abstractmethod
     def apply(self,gate,target,control=None,theta=None,param=None,update=True):
         pass
 
     def can_simulate_gate(self, gate):
-        return gate in self.basis_gates
+        return gate in (self.basis_gates + ["U"] + ["measure"])

--- a/quantpy/sympy/executor/simulator/cpu/__init__.py
+++ b/quantpy/sympy/executor/simulator/cpu/__init__.py
@@ -1,2 +1,0 @@
-
-from ._cpusim import CpuSimulator

--- a/quantpy/sympy/executor/simulator/numpy_simulator.py
+++ b/quantpy/sympy/executor/simulator/numpy_simulator.py
@@ -13,7 +13,6 @@ class NumpySimulator(BaseSimulator):
     def __init__(self,verbose=False):
         """
         @param verbose : output verbose comments for debug (default: false)
-        @return None
         """
         super().__init__()
         self.verbose = verbose
@@ -21,6 +20,11 @@ class NumpySimulator(BaseSimulator):
         self.basis_gates = ["x","z","y","h","s","t","cx","cz","m0","m1"]
 
     def initialize(self,n):
+        """
+        Initialize quantum states
+
+        @param n : number of qubits
+        """
         self.n = n
         self.dim = 2**n
         self.state = np.zeros(self.dim,dtype=np.complex128)
@@ -30,14 +34,15 @@ class NumpySimulator(BaseSimulator):
 
     def apply(self,gate,target,control=None,theta=None,param=None,update=True):
         """
-        apply quantum gate to the qubit(s)
+        Apply quantum gate to the qubit(s)
 
         @param gate : string or cupy kernel of applying gate
         @param target : target qubit index or indices
         @param control : control qubit index or indices (default: empty list)
         @param theta : rotation angle, used in rotation gate (default: None)
         @param params : description of unitary operation (default: empty list)
-        @update : The calculated state is placed in buffer-state. If update is Ture, swap current state with buffer after calculation. (default: True)
+        @param update : the calculated state is placed in buffer-state. If update is Ture, swap current state with buffer after calculation. (default: True)
+        @return return None if update==True, return trace value if update==False
         """
         if not hasattr(target,"__iter__"):
             target = [target]
@@ -106,7 +111,7 @@ class NumpySimulator(BaseSimulator):
 
     def update(self):
         """
-        swap buffer-state with the current state
+        Swap buffer-state with the current state
         """
         self.state,self.nstate = self.nstate,self.state
         self.currentTrace = None
@@ -114,7 +119,8 @@ class NumpySimulator(BaseSimulator):
     def trace(self,buffer=False):
         """
         take trace of the quantum state
-        @buffer : calculate trace of buffer-state (default: False)
+        @param buffer : calculate trace of buffer-state (default: False)
+        @return trace value of quantum states
         """
         if(self.verbose): print("Calculate trace")
         if(buffer):
@@ -126,8 +132,8 @@ class NumpySimulator(BaseSimulator):
 
     def normalize(self,eps=1e-16):
         """
-        normalize quantum state
-        @eps : if trace is smaller than eps, raise error for avoiding Nan (default: 1e-16)
+        Normalize quantum state
+        @param eps : if trace is smaller than eps, raise error for avoiding Nan (default: 1e-16)
         """
         if(self.currentTrace is None):
             self.trace()
@@ -139,16 +145,16 @@ class NumpySimulator(BaseSimulator):
 
     def asnumpy(self):
         """
-        recieve quantum state as numpy matrix.
-        Do nothing in numpy
+        Return the current quantum state as numpy array.
+        @return numpy array of the current quantum state
         """
         return self.state
 
     def __str__(self,eps=1e-10):
         """
-        overload string function
-        return bra-ket representation of current quantum state (very slow when n is large)
-        @eps : ignore amplitude smaller than eps when we convert state to str
+        Return bra-ket representation of current quantum state (very slow when n is large)
+        @param eps : ignore amplitude smaller than eps when we convert state to str
+        @return string representation of quantum states
         """
         fst = True
         ret = ""
@@ -165,4 +171,8 @@ class NumpySimulator(BaseSimulator):
         return ret
 
     def __bound(self,ind):
+        """
+        Check whether qubit index is valid
+        @return return true if valid
+        """
         return (0<=ind and ind<self.n)

--- a/quantpy/sympy/tests/test_hadamard_numpy.py
+++ b/quantpy/sympy/tests/test_hadamard_numpy.py
@@ -1,0 +1,38 @@
+import time
+
+from sympy.physics.quantum.gate import H
+from sympy.physics.quantum.qubit import Qubit
+
+from quantpy.sympy.qapply import qapply
+from quantpy.sympy.executor.classical_simulation_executor import ClassicalSimulationExecutor
+
+#from sympy.physics.quantum.qapply import qapply
+
+def test_hadamard_loop():
+    lp = 1  # loop size
+    ms = 10
+    me = 10
+    for n in range(ms, me+1):
+        ts = 2.6      # target second
+        lc = lp       # loop counter
+        ss = 0.0      # sum sec
+        for l in range(lc):
+            # print(n)
+            p = '0' * n
+            # print(p)
+            q = Qubit(p)
+            # print(q)
+            h = H(0)
+            for i in range(1,n):
+                h = H(i) * h
+            print(h)
+
+            executor = ClassicalSimulationExecutor()
+            start = time.time()
+            r = qapply(h * q, executor=executor)
+            elapsed_time = time.time() - start
+            ss += elapsed_time
+            print(executor.getStateStr())
+            print ("elapsed_time:\t{0},\t{1} [sec]".format(n,elapsed_time))
+        print("average:\t{0}x{1},\t{2} [sec]".format(n, lc, ss/lc))
+        assert ss/lc < ts


### PR DESCRIPTION
The following changes are applied.

=== CPU simulator is renamed to numpy simulator
Because simulators based on cython executed with CPU will be added, I think the name "CPU-simulator" for numpy-native simulator is confusing.
I renamed cpusim to numpy_simulator.


=== Bugs about basis_gates are fixed
 1. Though the "classical simulator" class specifies their basis gates, "classical simulator executor" class has not used it.
I fixed compilation process about basis gates.

 2. Operation "measure" is not included in basis gate. Such a non-gate operation has been classified as an unsupported gate. 
I added "measure" and "U" to check-list of "supported operations" as temporal modification.
I guess the specifications about basis_gate should be examined later.


=== Test for numpy simulator is added
I added numpy-simulator version of a test script as quantpy.sympy.tests.test_hadamard_numpy.py


=== Comments are added
Comments are added to 
quantpy.simpy.executor.classical_simulation_executor
quantpy.simpy.executor.simulator.numpy_simulator
