### PR TITLE
Ibmq fix

### DIFF
--- a/quantpy/sympy/executor/ibmq_executor.py
+++ b/quantpy/sympy/executor/ibmq_executor.py
@@ -2,11 +2,11 @@
 """definition of IBMQExecutor class
 """
 
-import sympy
 import qiskit
 from qiskit import BasicAer
 
 from quantpy.sympy.executor._base_quantum_executor import BaseQuantumExecutor
+
 
 class IBMQExecutor(BaseQuantumExecutor):
     """IBMQExecutor Class
@@ -28,7 +28,7 @@ class IBMQExecutor(BaseQuantumExecutor):
                   (default: 'local_qasm_simulator').
                 * ``shots``: shots using QISKit's execute function
                   (default: 1024).
-                * ``qiskit_options`` : dict of additional parameters 
+                * ``qiskit_options`` : dict of additional parameters
                   for qiskit's ``execute`` method.
                   (for example, ``{"max_credits":3}``)
         """
@@ -47,9 +47,9 @@ class IBMQExecutor(BaseQuantumExecutor):
                   (default: True).
         """
         with_measure = options.get('with_measure', True)
-        qasm = self.to_qasm(circuit, with_measure = with_measure)
+        qasm = self.to_qasm(circuit, with_measure=with_measure)
         quantum_circuit = qiskit.QuantumCircuit.from_qasm_str(qasm)
-        try: 
+        try:
             from qiskit import execute
             job = execute(quantum_circuit, backend=self.backend, shots=self.shots, **self.extra_args)
             return job.result().get_counts()

--- a/quantpy/sympy/tests/test_executors.py
+++ b/quantpy/sympy/tests/test_executors.py
@@ -3,16 +3,16 @@ import pytest
 from sympy.physics.quantum.gate import H
 from sympy.physics.quantum.qubit import Qubit
 from quantpy.sympy.qapply import qapply
-import sympy
 from quantpy.sympy.executor.classical_simulation_executor import ClassicalSimulationExecutor
 from quantpy.sympy.executor.sympy_executor import SymPyExecutor
 from quantpy.sympy.executor.ibmq_executor import IBMQExecutor
+
 
 def test_executors():
     c = H(2)*H(1)*H(0)*Qubit('000')
     for executor in (SymPyExecutor(), ClassicalSimulationExecutor(), IBMQExecutor()):
         result = qapply(c, executor=executor)
-        ## TODO : can we check the result?
+        # TODO : can we check the result?
         print(result)
         print(result.__class__)
 
@@ -30,6 +30,6 @@ def test_ibmq_real_device():
 
     c = H(0)*Qubit('0')
     # XXX : this may takes long time and no feedback of job status yet
-    result = qapply(c, executor=IBMQExecutor(backend=backend, shots=1024, qiskit_options={'max_credits':3}))
+    result = qapply(c, executor=IBMQExecutor(backend=backend, shots=1024, qiskit_options={'max_credits': 3}))
     print(result)
     print(result.__class__)

--- a/quantpy/sympy/tests/test_executors.py
+++ b/quantpy/sympy/tests/test_executors.py
@@ -1,0 +1,35 @@
+import pytest
+
+from sympy.physics.quantum.gate import H
+from sympy.physics.quantum.qubit import Qubit
+from quantpy.sympy.qapply import qapply
+import sympy
+from quantpy.sympy.executor.classical_simulation_executor import ClassicalSimulationExecutor
+from quantpy.sympy.executor.sympy_executor import SymPyExecutor
+from quantpy.sympy.executor.ibmq_executor import IBMQExecutor
+
+def test_executors():
+    c = H(2)*H(1)*H(0)*Qubit('000')
+    for executor in (SymPyExecutor(), ClassicalSimulationExecutor(), IBMQExecutor()):
+        result = qapply(c, executor=executor)
+        ## TODO : can we check the result?
+        print(result)
+        print(result.__class__)
+
+
+@pytest.mark.skip(reason="this is an example rather than real test. please note this can take long time and there's no job monitoring implemented.")
+def test_ibmq_real_device():
+    # code mostly from qiskit's "getting started"
+    # https://qiskit.org/documentation/getting_started_with_qiskit_terra.html#running-circuits-on-real-devices
+    from qiskit import IBMQ
+    from qiskit.providers.ibmq import least_busy
+    IBMQ.load_accounts()
+    real_device = IBMQ.backends(filters=lambda x: not x.configuration().simulator)
+    backend = least_busy(real_device)
+    print("The best backend is " + backend.name())
+
+    c = H(0)*Qubit('0')
+    # XXX : this may takes long time and no feedback of job status yet
+    result = qapply(c, executor=IBMQExecutor(backend=backend, shots=1024, qiskit_options={'max_credits':3}))
+    print(result)
+    print(result.__class__)


### PR DESCRIPTION
This fixes #36. I have confirmed the execution in local simulator, but couldn't tested with the real device (it took too long without feedback, so I gave up).

There are several changes from qiskit 0.5 to qiskit-terra, so the `__init__` of executor was also changed accordingly.
- removed `api_key` option, because of the change of qiskit initialization. Now users need to use `IBMQ.load_accounts()` etc before creating executor object  (please see [qiskit doc](https://qiskit.org/documentation/getting_started_with_qiskit_terra.html#running-circuits-on-real-devices) for more details)
- added `qiskit_options` option to pass extra parameters to qiskit's `execute` function, just in case more control of execution is required.

---
pre-PR checks:
- [x] follow the Style Guide for Python Code as described [here](http://legacy.python.org/dev/peps/pep-0008/)
- [x] Make sure you properly unit test your changes.
- [x] Run the unit tests to make sure they all pass.
- [x] Write commit messages that make sense, and rebase your branch before submitting your pull request.
- [x] Send pull requests to the feature-{%code-name%} branch, not the master branch and the develop branch.
