### PR TITLE
Qexperiment

### DIFF
--- a/quantpy/sympy/executor/_base_quantum_executor.py
+++ b/quantpy/sympy/executor/_base_quantum_executor.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -* coding:utf-8 -*-
 """definition of BaseQuantumExecutor class
 """
 from abc import abstractmethod
@@ -20,6 +20,13 @@ class BaseQuantumExecutor:
         @return: None
         """
         return None
+
+    @abstractmethod
+    def experiment(self, circuit, shot, **options):
+        """Execute circuit ``shot`` times and return the result.
+        @return: dict qubit string (as '0101') -> int
+        """
+        pass
 
     def to_qasm(self, sympy_expr, **options):
         """QuantumExecutor classes' commom method.

--- a/quantpy/sympy/executor/_base_quantum_executor.py
+++ b/quantpy/sympy/executor/_base_quantum_executor.py
@@ -22,9 +22,9 @@ class BaseQuantumExecutor:
         return None
 
     @abstractmethod
-    def experiment(self, circuit, shot, **options):
-        """Execute circuit ``shot`` times and return the result.
-        @return: dict qubit string (as '0101') -> int
+    def experiment(self, circuit, shots, **options):
+        """Execute circuit ``shots`` times and return the result.
+        @return: dict {Qubit -> int} or {str -> int} like [{'0001': 104}, {..}..]
         """
         pass
 

--- a/quantpy/sympy/executor/classical_simulation_executor.py
+++ b/quantpy/sympy/executor/classical_simulation_executor.py
@@ -35,7 +35,7 @@ class ClassicalSimulationExecutor(BaseQuantumExecutor):
         qobj = circuits_to_qobj(circuit, QasmSimulatorPy())
         json = qobj_to_dict(qobj)["experiments"][0]
         self.simulate(json)
-        return str(self.simulator)
+        return self.simulator.to_coefficients()
 
     def simulate(self, circuitJson):
         """
@@ -115,3 +115,17 @@ class ClassicalSimulationExecutor(BaseQuantumExecutor):
         @return string representation of the current quantum state
         """
         return str(self.simulator)
+
+    @staticmethod
+    def _default_random_sequence(num):
+        import random
+        return (random.random() for _ in range(num))
+
+    @staticmethod
+    def step_sequence(num):
+        """
+        dummy "radom" method used for testing.
+        This yields list [0, 1/n, 2/n...], 
+        so you can easily estimate the number of result from shot
+        """
+        return (i / num for i in range(num))

--- a/quantpy/sympy/executor/ibmq_executor.py
+++ b/quantpy/sympy/executor/ibmq_executor.py
@@ -39,8 +39,19 @@ class IBMQExecutor(BaseQuantumExecutor):
         self.shots = shots
         self.extra_args = options.get('qiskit_options', {})
 
+    def experiment(self, circuit, shots, **options):
+        # ``shots`` is duplicate with self.shots. so copy it while execution
+        _shots = self.shots
+        try:
+            self.shots = shots
+            job = self.execute(circuit, **options)
+            return job.result().get_counts()
+        finally:
+            self.shots = _shots
+
     def execute(self, circuit, **options):
         """
+                execute the circuit and return job object
                 The following options are valid:
 
                 * ``with_measure``: qapply with measure flag
@@ -52,7 +63,7 @@ class IBMQExecutor(BaseQuantumExecutor):
         try:
             from qiskit import execute
             job = execute(quantum_circuit, backend=self.backend, shots=self.shots, **self.extra_args)
-            return job.result().get_counts()
+            return job
         except qiskit.QiskitError as ex:
             print("error:", ex.args)
-            return
+            return None

--- a/quantpy/sympy/executor/simulator/numpy_simulator.py
+++ b/quantpy/sympy/executor/simulator/numpy_simulator.py
@@ -150,25 +150,28 @@ class NumpySimulator(BaseSimulator):
         """
         return self.state
 
+    def to_coefficients(self, eps=1e-10):
+        """
+        Returns dict {state : coefficients}.
+        state is a string of bit patterns
+        """
+        result = {}
+        FORMAT = "{:0%db}" % self.n  # like "{04b} for 4 bits
+        for ind in range(self.dim):
+            val = self.state[ind]
+            if abs(val) < eps:
+                continue
+            result[FORMAT.format(ind)] = val
+        return result
+
     def __str__(self,eps=1e-10):
         """
         Return bra-ket representation of current quantum state (very slow when n is large)
         @param eps : ignore amplitude smaller than eps when we convert state to str
         @return string representation of quantum states
         """
-        fst = True
-        ret = ""
-        for ind in range(self.dim):
-            val = self.state[ind]
-            if(abs(val)<eps):
-                continue
-            else:
-                if(fst):
-                    fst = False
-                else:
-                    ret += " + "
-                ret += str(val) + "|" + format(ind,"b").zfill(self.n)[::-1]+ ">"
-        return ret
+        pairs = self.to_coefficients()
+        return " + ".join(["{}|{}>".format(v, k) for k, v in pairs.items()])
 
     def __bound(self,ind):
         """

--- a/quantpy/sympy/executor/sympy_executor.py
+++ b/quantpy/sympy/executor/sympy_executor.py
@@ -12,7 +12,6 @@ class SymPyExecutor(BaseQuantumExecutor):
         """Initial method.
         """
         super().__init__()
-        self.random_sequence = self.__class__._default_random_sequence
 
     def execute(self, circuit, **options):
         """This method calls sympy.physics.quantum.qapply transparently.

--- a/quantpy/sympy/executor/sympy_executor.py
+++ b/quantpy/sympy/executor/sympy_executor.py
@@ -25,9 +25,8 @@ class SymPyExecutor(BaseQuantumExecutor):
         from sympy.physics.quantum.qubit import measure_all
         import sympy
         # calculate probability from the result of ``qapply``
-        res = measure_all(sympy_qapply(circuit, **options))
-        # make list of tuples (``qubit str``, ``probability``) as ('0000', 0.125), ('0001', 0.25)..
-        probabilities = [(''.join([str(x) for x in k.qubit_values]), v) for k,v in res]
+        probabilities = measure_all(sympy_qapply(circuit, **options))
+        # make list of tuples (``qubit str``, ``probability``) as (Qubit('0000'), 0.125), (Qubit('0001'), 0.25)..
         result = defaultdict(int)
         for qubit, probability in probabilities:
             result[qubit] = sympy.simplify(probability * shots)

--- a/quantpy/sympy/executor/sympy_executor.py
+++ b/quantpy/sympy/executor/sympy_executor.py
@@ -24,21 +24,13 @@ class SymPyExecutor(BaseQuantumExecutor):
         """
         from sympy.physics.quantum.qubit import measure_all
         import sympy
-        # calculate possibilities from the result of ``qapply``
+        # calculate probability from the result of ``qapply``
         res = measure_all(sympy_qapply(circuit, **options))
-        # make list of tuples (``qubit str``, ``possibility``) as ('0000', 0.125), ('0001', 0.25)..
-        possibilities = [(''.join([str(x) for x in k.qubit_values]), sympy.N(v)) for k,v in res]
-
-        print(self.random_sequence)
-        # iterate random numbers and count the observation of each qubit
+        # make list of tuples (``qubit str``, ``probability``) as ('0000', 0.125), ('0001', 0.25)..
+        probabilities = [(''.join([str(x) for x in k.qubit_values]), v) for k,v in res]
         result = defaultdict(int)
-        for r in self.random_sequence(shots):
-            threashold = 0.0
-            for qubit, possibility in possibilities:
-                threashold += possibility
-                if r < threashold:
-                    result[qubit] += 1
-                    break
+        for qubit, probability in probabilities:
+            result[qubit] = sympy.simplify(probability * shots)
         return result
 
     @staticmethod

--- a/quantpy/sympy/executor/sympy_executor.py
+++ b/quantpy/sympy/executor/sympy_executor.py
@@ -31,16 +31,3 @@ class SymPyExecutor(BaseQuantumExecutor):
             result[qubit] = sympy.simplify(probability * shots)
         return result
 
-    @staticmethod
-    def _default_random_sequence(num):
-        import random
-        return (random.random() for _ in range(num))
-
-    @staticmethod
-    def step_sequence(num):
-        """
-        dummy "radom" method used for testing.
-        This yields list [0, 1/n, 2/n...], 
-        so you can easily estimate the number of result from shot
-        """
-        return (i / num for i in range(num))

--- a/quantpy/sympy/qapply.py
+++ b/quantpy/sympy/qapply.py
@@ -2,7 +2,7 @@
 """Logic for applying operators to states.
 """
 
-__all__ = ['qapply']
+__all__ = ['qapply', 'qexperiment']
 
 from quantpy.sympy.executor.sympy_executor import SymPyExecutor
 
@@ -27,3 +27,8 @@ def qapply(circuit, **options):
     """
     executor = options.get('executor', SymPyExecutor())
     return executor.execute(circuit, **options)
+
+
+def qexperiment(circuit, slot, executor=SymPyExecutor(), **options):
+    executor = options.get('executor', SymPyExecutor())
+    return executor.experiment(circuit, slot, **options)

--- a/quantpy/sympy/qapply.py
+++ b/quantpy/sympy/qapply.py
@@ -29,6 +29,5 @@ def qapply(circuit, **options):
     return executor.execute(circuit, **options)
 
 
-def qexperiment(circuit, slot, executor=SymPyExecutor(), **options):
-    executor = options.get('executor', SymPyExecutor())
+def qexperiment(circuit, slot=1024, executor=SymPyExecutor(), **options):
     return executor.experiment(circuit, slot, **options)

--- a/quantpy/sympy/qapply.py
+++ b/quantpy/sympy/qapply.py
@@ -5,6 +5,7 @@
 __all__ = ['qapply', 'qexperiment']
 
 from quantpy.sympy.executor.sympy_executor import SymPyExecutor
+from sympy.physics.quantum.qubit import Qubit
 
 def qapply(circuit, **options):
     """Apply quantum operators to quantum states in a quantum expression.
@@ -29,5 +30,37 @@ def qapply(circuit, **options):
     return executor.execute(circuit, **options)
 
 
-def qexperiment(circuit, slot=1024, executor=SymPyExecutor(), **options):
-    return executor.experiment(circuit, slot, **options)
+def qexperiment(circuit, shots=1024, executor=SymPyExecutor(), **options):
+    """Apply quantum operators to quantum states and execute a measurement.
+    This is mostly equivalent to sympy code ``measure_all(qapply(circuit))``,
+    but this returns the occurrence count of each state instead of probability.
+
+    @param circuit: Expr
+        Symbol description expression that can be handled with SymPy
+        showing quantum operator and quantum state.
+        Analyze the operation order of the quantum operator, and apply them to the quantum state.
+        Please note that most backend doesn't accept sympy Symbols.
+
+    @param slots: int
+        Repeat count of the measurement executed.
+
+    @param executor: executor object
+        The executor used for this experiment.
+
+    @param options: dict
+        The extra parameters passed to executor.
+
+    @return : dict {Qubit -> int}
+        dict of each Qubit and the number of the count observed.
+        States not observed may be omitted.
+        For example, ``{Qubit(0): 513, Qubit(1): 511}`` or ``{Qubit(1):1024}``
+    """
+    _result = executor.experiment(circuit, shots, **options)
+    # make sure the return is Sympy Qubit
+    result = {}
+    for k, v in _result.items():
+        if not isinstance(k, Qubit):
+            result[Qubit(k)] = v
+        else:
+            result[k] = v
+    return result

--- a/quantpy/sympy/tests/test_qexperiment.py
+++ b/quantpy/sympy/tests/test_qexperiment.py
@@ -8,6 +8,7 @@ from quantpy.sympy.qapply import qexperiment
 
 from quantpy.sympy.executor._base_quantum_executor import BaseQuantumExecutor
 from quantpy.sympy.executor.sympy_executor import SymPyExecutor
+from quantpy.sympy.executor.ibmq_executor import IBMQExecutor
 
 
 class MockExecutor(BaseQuantumExecutor):
@@ -40,6 +41,17 @@ def test_qexperiment_default():
     assert len(result) == 8
 
 
+def test_qexperiment_sympy_with_symbols():
+    import sympy as sp
+    a, b = sp.symbols('alpha, beta') 
+    psi = a*Qubit('00') + b*Qubit('11')
+    executor = SymPyExecutor()
+    result = qexperiment(X(0) * psi, executor=executor)
+    norm = sp.Abs(a)**2 + sp.Abs(b)**2
+    assert result == {'01': 1024 * a*a.conjugate() / norm,
+                      '10': 1024 * b*b.conjugate() / norm}
+
+
 def test_qexperiment_sympy_value1():
     c = H(2)*H(1)*H(0)*Qubit('000')
     executor = SymPyExecutor()
@@ -56,4 +68,12 @@ def test_qexperiment_sympy_value1():
             '110': 128,
             '111': 128,
             }
+
+
+def test_qexperiment_ibmq():
+    c = H(2)*H(1)*H(0)*Qubit('000')
+    result = qexperiment(c, executor=IBMQExecutor())
+    assert len(result) == 8
+
+
 

--- a/quantpy/sympy/tests/test_qexperiment.py
+++ b/quantpy/sympy/tests/test_qexperiment.py
@@ -9,6 +9,7 @@ from quantpy.sympy.qapply import qexperiment
 from quantpy.sympy.executor._base_quantum_executor import BaseQuantumExecutor
 from quantpy.sympy.executor.sympy_executor import SymPyExecutor
 from quantpy.sympy.executor.ibmq_executor import IBMQExecutor
+from quantpy.sympy.executor.classical_simulation_executor import ClassicalSimulationExecutor
 
 
 class MockExecutor(BaseQuantumExecutor):
@@ -74,4 +75,26 @@ def test_qexperiment_ibmq():
     assert len(result) == 8
 
 
+def step_sequence(num):
+    """
+    dummy "radom" method used for testing.
+    This yields list [0, 1/n, 2/n...], 
+    so you can easily estimate the number of result from the count
+    """
+    return (i / num for i in range(num))
+
+def test_qexperiment_numpy():
+    c = H(2)*H(1)*H(0)*Qubit('000')
+    executor = ClassicalSimulationExecutor()
+    result = qexperiment(c, 1024, executor, random=step_sequence)
+    assert result == {
+            Qubit('000'): 128,
+            Qubit('001'): 128,
+            Qubit('010'): 128,
+            Qubit('011'): 128,
+            Qubit('100'): 128,
+            Qubit('101'): 128,
+            Qubit('110'): 128,
+            Qubit('111'): 128,
+            }
 

--- a/quantpy/sympy/tests/test_qexperiment.py
+++ b/quantpy/sympy/tests/test_qexperiment.py
@@ -55,8 +55,6 @@ def test_qexperiment_sympy_with_symbols():
 def test_qexperiment_sympy_value1():
     c = H(2)*H(1)*H(0)*Qubit('000')
     executor = SymPyExecutor()
-    # prepare "random numbers" for test
-    executor.random_sequence = SymPyExecutor.step_sequence
     result = qexperiment(c, 1024, executor)
     assert result == {
             Qubit('000'): 128,

--- a/quantpy/sympy/tests/test_qexperiment.py
+++ b/quantpy/sympy/tests/test_qexperiment.py
@@ -98,3 +98,8 @@ def test_qexperiment_numpy():
             Qubit('111'): 128,
             }
 
+def test_qexperiment_numpy_random():
+    c = H(2)*H(1)*H(0)*Qubit('000')
+    executor = ClassicalSimulationExecutor()
+    result = qexperiment(c, 612, executor)
+    assert 612 == sum((x for x in result.values()))

--- a/quantpy/sympy/tests/test_qexperiment.py
+++ b/quantpy/sympy/tests/test_qexperiment.py
@@ -48,8 +48,8 @@ def test_qexperiment_sympy_with_symbols():
     executor = SymPyExecutor()
     result = qexperiment(X(0) * psi, executor=executor)
     norm = sp.Abs(a)**2 + sp.Abs(b)**2
-    assert result == {'01': 1024 * a*a.conjugate() / norm,
-                      '10': 1024 * b*b.conjugate() / norm}
+    assert result == {Qubit('01'): 1024 * a*a.conjugate() / norm,
+                      Qubit('10'): 1024 * b*b.conjugate() / norm}
 
 
 def test_qexperiment_sympy_value1():
@@ -59,14 +59,14 @@ def test_qexperiment_sympy_value1():
     executor.random_sequence = SymPyExecutor.step_sequence
     result = qexperiment(c, 1024, executor)
     assert result == {
-            '000': 128,
-            '001': 128,
-            '010': 128,
-            '011': 128,
-            '100': 128,
-            '101': 128,
-            '110': 128,
-            '111': 128,
+            Qubit('000'): 128,
+            Qubit('001'): 128,
+            Qubit('010'): 128,
+            Qubit('011'): 128,
+            Qubit('100'): 128,
+            Qubit('101'): 128,
+            Qubit('110'): 128,
+            Qubit('111'): 128,
             }
 
 

--- a/quantpy/sympy/tests/test_qexperiment.py
+++ b/quantpy/sympy/tests/test_qexperiment.py
@@ -1,0 +1,59 @@
+from sympy.physics.quantum.gate import H, X, Y, Z, CNOT, SWAP, CGateS
+from sympy.physics.quantum.gate import IdentityGate as _I
+from sympy.physics.quantum.gate import UGate as U
+from sympy.physics.quantum.qubit import Qubit
+
+from sympy.physics.quantum.qapply import qapply as sympy_qapply
+from quantpy.sympy.qapply import qexperiment
+
+from quantpy.sympy.executor._base_quantum_executor import BaseQuantumExecutor
+from quantpy.sympy.executor.sympy_executor import SymPyExecutor
+
+
+class MockExecutor(BaseQuantumExecutor):
+    def experiment(self, circuit, shots, **options):
+        self.circuit = circuit
+        self.shots = shots
+        self.options = options
+        return {'0': shots}
+    
+
+def test_qexperiment_parameters():
+    """
+    checks if all parameters are properly passed to executors
+    """
+    executor = MockExecutor()
+    c = Qubit('0')
+    result = qexperiment(c, 987654321, executor, test='dummy', otherparameters=1234)
+
+    assert executor.circuit is c
+    assert executor.shots is 987654321
+    assert executor.options == {'test': 'dummy', 'otherparameters':1234}
+
+
+def test_qexperiment_default():
+    c = H(2)*H(1)*H(0)*Qubit('000')
+    result = qexperiment(c)
+    # total should be same as shots
+    assert sum((v for v in result.values())) == 1024
+    # probability that misses one state in 1024 is less than 10^-60
+    assert len(result) == 8
+
+
+def test_qexperiment_sympy_value1():
+    c = H(2)*H(1)*H(0)*Qubit('000')
+    executor = SymPyExecutor()
+    # prepare "random numbers" for test
+    executor.random_sequence = SymPyExecutor.step_sequence
+    result = qexperiment(c, 1024, executor)
+    assert result == {
+            '000': 128,
+            '001': 128,
+            '010': 128,
+            '011': 128,
+            '100': 128,
+            '101': 128,
+            '110': 128,
+            '111': 128,
+            }
+


### PR DESCRIPTION
implementing the idea based on the discussion in slack.
Implementation for `SympyExecutor` and `IBMQExecutor` have done. (Numpy is not yet done)

- qapply returns an object that depends on executer
  - SympyExecutor returns Sympy expression
  - IBMQExecutor returns qiskit "job" object
  - ClassicalSimulationExecutor : TBD
- qexperiment returns the list of (state in string, probability)

```
c = H(2)*H(1)*H(0)*Qubit('000')
result = qexperiment(c, executor=IBMQExecutor())
print(result)
# output: {'100': 132, '101': 118, '011': 107, '000': 149, '010': 116, '110': 142, '001': 120, '111': 140}
```